### PR TITLE
docs: sync workflow/protections in README and index-developpement

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,39 @@ Arborescence (extrait):
 - `.github/workflows/ci.yml`  pipeline CI
 - `docs/`  documentation projet
 
+## Workflow Git et CI/CD
+
+- Développer sur une branche `feature/*`.
+- Ouvrir une Pull Request (PR) vers `main`.
+- La CI GitHub Actions doit passer au vert avec les checks stricts requis:
+  - `frontend-build`
+  - `backend-install`
+- Merge en mode « squash » (historique linéaire garanti). La suppression de la branche est réalisée après merge.
+- Option: activer l’auto‑merge sur la PR (`gh pr merge --squash --delete-branch --auto`) pour merger automatiquement dès que la CI est verte.
+
+Procédure type:
+```bash
+git switch -c feature/ma-fonctionnalite
+# ... commits ...
+git push -u origin feature/ma-fonctionnalite
+gh pr create -B main -H feature/ma-fonctionnalite -t "feat: ..." -b "..."
+gh pr merge --squash --delete-branch --auto
+```
+
+## Protections de branche (GitHub)
+
+- PR obligatoire pour modifier `main` (push direct interdit).
+- Status checks requis (mode strict): `frontend-build`, `backend-install`.
+- Reviews non obligatoires (CODEOWNERS présent mais non bloquant).
+- Historique linéaire imposé (merge commit interdit, squash recommandé).
+- Conversations à résoudre avant merge, force‑push interdit.
+
+## Sécurité opérationnelle (rappels)
+
+- Secrets via variables d’environnement uniquement; `.env` ignoré.
+- Authentification JWT, mots de passe hashés avec `bcrypt`.
+- RBAC strict côté serveur (`player` | `instructor` | `admin`).
+- Middlewares: `helmet` (en‑têtes), `cors` (origines limitées), `express-rate-limit` (points sensibles).
+- Validation d’entrée systématique (`express-validator`), requêtes DB via Mongoose (prévention NoSQL injection).
+- Logs structurés sans données sensibles; surveillance des endpoints sensibles.
+- Fichiers binaires (PDF/vidéos): stockage externe (OVH Object Storage), jamais en base de données.

--- a/docs/index-developpement.md
+++ b/docs/index-developpement.md
@@ -82,3 +82,40 @@ docker compose logs -f --tail=100 backend
 - Tous les commentaires code en français (contexte projet local). Commits conventionnels (anglais).
 - Pas de stockage de binaires en DB. Secrets via variables d’environnement uniquement.
 - Journalisation utile sans données sensibles. Rate limiting présent sur endpoints critiques.
+
+## Workflow Git et CI/CD
+
+- Développer sur une branche `feature/*`.
+- Ouvrir une Pull Request (PR) vers `main`.
+- La CI GitHub Actions doit passer au vert avec les checks stricts requis:
+  - `frontend-build`
+  - `backend-install`
+- Merge en mode « squash » (historique linéaire garanti). La suppression de la branche est réalisée après merge.
+- Option: activer l’auto‑merge sur la PR (`gh pr merge --squash --delete-branch --auto`) pour merger automatiquement dès que la CI est verte.
+
+Procédure type:
+```bash
+git switch -c feature/ma-fonctionnalite
+# ... commits ...
+git push -u origin feature/ma-fonctionnalite
+gh pr create -B main -H feature/ma-fonctionnalite -t "feat: ..." -b "..."
+gh pr merge --squash --delete-branch --auto
+```
+
+## Protections de branche (GitHub)
+
+- PR obligatoire pour modifier `main` (push direct interdit).
+- Status checks requis (mode strict): `frontend-build`, `backend-install`.
+- Reviews non obligatoires (CODEOWNERS présent mais non bloquant).
+- Historique linéaire imposé (merge commit interdit, squash recommandé).
+- Conversations à résoudre avant merge, force‑push interdit.
+
+## Sécurité opérationnelle (rappels)
+
+- Secrets via variables d’environnement uniquement; `.env` ignoré.
+- Authentification JWT, mots de passe hashés avec `bcrypt`.
+- RBAC strict côté serveur (`player` | `instructor` | `admin`).
+- Middlewares: `helmet` (en‑têtes), `cors` (origines limitées), `express-rate-limit` (points sensibles).
+- Validation d’entrée systématique (`express-validator`), requêtes DB via Mongoose (prévention NoSQL injection).
+- Logs structurés sans données sensibles; surveillance des endpoints sensibles.
+- Fichiers binaires (PDF/vidéos): stockage externe (OVH Object Storage), jamais en base de données.


### PR DESCRIPTION
This PR syncs documentation updates:
- README.md: add Workflow Git & CI/CD, Branch protections, Security ops
- docs/index-developpement.md: replicate the same sections without reduction

Workflow: feature branch -> PR -> CI checks -> squash merge (auto-merge enabled).