### PR TITLE
ci: add frontend and backend GitHub Actions workflows

### DIFF
--- a/.github/workflows/backend-install.yml
+++ b/.github/workflows/backend-install.yml
@@ -1,0 +1,38 @@
+name: backend-install
+
+on:
+  push:
+    branches: [ main, develop, "feature/**" ]
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-install.yml"
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-install.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          npm ci || npm install

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,0 +1,43 @@
+name: frontend-build
+
+on:
+  push:
+    branches: [ main, develop, "feature/**" ]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-build.yml"
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-build.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          npm ci || npm install
+
+      - name: Build (Vite)
+        env:
+          VITE_API_URL: /api/v1
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -15,3 +15,39 @@ Arborescence (extrait):
 - `.github/workflows/ci.yml`  pipeline CI
 - `docs/`  documentation projet
 
+## Workflow Git et CI/CD
+
+- Développer sur une branche `feature/*`.
+- Ouvrir une Pull Request (PR) vers `main`.
+- La CI GitHub Actions doit passer au vert avec les checks stricts requis:
+  - `frontend-build`
+  - `backend-install`
+- Merge en mode « squash » (historique linéaire garanti). La suppression de la branche est réalisée après merge.
+- Option: activer l’auto‑merge sur la PR (`gh pr merge --squash --delete-branch --auto`) pour merger automatiquement dès que la CI est verte.
+
+Procédure type:
+```bash
+git switch -c feature/ma-fonctionnalite
+# ... commits ...
+git push -u origin feature/ma-fonctionnalite
+gh pr create -B main -H feature/ma-fonctionnalite -t "feat: ..." -b "..."
+gh pr merge --squash --delete-branch --auto
+```
+
+## Protections de branche (GitHub)
+
+- PR obligatoire pour modifier `main` (push direct interdit).
+- Status checks requis (mode strict): `frontend-build`, `backend-install`.
+- Reviews non obligatoires (CODEOWNERS présent mais non bloquant).
+- Historique linéaire imposé (merge commit interdit, squash recommandé).
+- Conversations à résoudre avant merge, force‑push interdit.
+
+## Sécurité opérationnelle (rappels)
+
+- Secrets via variables d’environnement uniquement; `.env` ignoré.
+- Authentification JWT, mots de passe hashés avec `bcrypt`.
+- RBAC strict côté serveur (`player` | `instructor` | `admin`).
+- Middlewares: `helmet` (en‑têtes), `cors` (origines limitées), `express-rate-limit` (points sensibles).
+- Validation d’entrée systématique (`express-validator`), requêtes DB via Mongoose (prévention NoSQL injection).
+- Logs structurés sans données sensibles; surveillance des endpoints sensibles.
+- Fichiers binaires (PDF/vidéos): stockage externe (OVH Object Storage), jamais en base de données.

--- a/docs/index-developpement.md
+++ b/docs/index-developpement.md
@@ -82,3 +82,40 @@ docker compose logs -f --tail=100 backend
 - Tous les commentaires code en français (contexte projet local). Commits conventionnels (anglais).
 - Pas de stockage de binaires en DB. Secrets via variables d’environnement uniquement.
 - Journalisation utile sans données sensibles. Rate limiting présent sur endpoints critiques.
+
+## Workflow Git et CI/CD
+
+- Développer sur une branche `feature/*`.
+- Ouvrir une Pull Request (PR) vers `main`.
+- La CI GitHub Actions doit passer au vert avec les checks stricts requis:
+  - `frontend-build`
+  - `backend-install`
+- Merge en mode « squash » (historique linéaire garanti). La suppression de la branche est réalisée après merge.
+- Option: activer l’auto‑merge sur la PR (`gh pr merge --squash --delete-branch --auto`) pour merger automatiquement dès que la CI est verte.
+
+Procédure type:
+```bash
+git switch -c feature/ma-fonctionnalite
+# ... commits ...
+git push -u origin feature/ma-fonctionnalite
+gh pr create -B main -H feature/ma-fonctionnalite -t "feat: ..." -b "..."
+gh pr merge --squash --delete-branch --auto
+```
+
+## Protections de branche (GitHub)
+
+- PR obligatoire pour modifier `main` (push direct interdit).
+- Status checks requis (mode strict): `frontend-build`, `backend-install`.
+- Reviews non obligatoires (CODEOWNERS présent mais non bloquant).
+- Historique linéaire imposé (merge commit interdit, squash recommandé).
+- Conversations à résoudre avant merge, force‑push interdit.
+
+## Sécurité opérationnelle (rappels)
+
+- Secrets via variables d’environnement uniquement; `.env` ignoré.
+- Authentification JWT, mots de passe hashés avec `bcrypt`.
+- RBAC strict côté serveur (`player` | `instructor` | `admin`).
+- Middlewares: `helmet` (en‑têtes), `cors` (origines limitées), `express-rate-limit` (points sensibles).
+- Validation d’entrée systématique (`express-validator`), requêtes DB via Mongoose (prévention NoSQL injection).
+- Logs structurés sans données sensibles; surveillance des endpoints sensibles.
+- Fichiers binaires (PDF/vidéos): stockage externe (OVH Object Storage), jamais en base de données.


### PR DESCRIPTION
This PR adds two GitHub Actions workflows to enforce build/install checks per docs/index-developpement.md.\n\n- frontend-build.yml: builds the Vite frontend with Node 20 and VITE_API_URL=/api/v1; caches npm by lockfile.\n- backend-install.yml: installs backend deps with Node 20; caches npm by lockfile.\n\nBoth workflows:\n- Trigger on push/PR affecting respective folders.\n- Use concurrency to cancel in-progress runs on the same ref.\n- Do not require any secrets.\n\nOnce merged, set required status checks on main to: frontend-build and backend-install (Branch protection).