### PR TITLE
dashboard tile tweaks 1

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -99,9 +99,13 @@ const DashboardPage = () => {
 
         if (extraRes.status === 'fulfilled') {
           const arr = (extraRes.value?.data?.data?.settings ?? []) as Array<{ key: string; title?: string | null; content?: string; mediaUrl?: string | null }>;
-          setExtraTiles(
-            arr.map((s) => ({ key: s.key, title: s.title ?? null, content: s.content || '', mediaUrl: s.mediaUrl ?? null }))
-          );
+          const mapped = arr.map((s) => ({ key: s.key, title: s.title ?? null, content: s.content || '', mediaUrl: s.mediaUrl ?? null }));
+          setExtraTiles(mapped);
+          // Si une tuile ".header" existe avec mediaUrl, l'utiliser comme image d'en-tête par défaut
+          const headerTile = mapped.find((s) => /\.header$/.test(s.key) && s.mediaUrl);
+          if (headerTile?.mediaUrl) {
+            setHeaderImageUrl((prev) => prev ?? headerTile!.mediaUrl!);
+          }
         } else {
           setExtraTiles([]);
         }


### PR DESCRIPTION
- **feat(dashboard): date-only timestamps, remove extra heading and club tile, 2-col grid, configurable header image, larger catchphrase**
- **chore: release dashboard-tile-tweaks-1 (2025-09-01 20:37:15)**
